### PR TITLE
Release v0.1.0 - Initial Public Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-12-03
+
+### Added
+
+- Initial release of `desisky` package
+- Pre-trained broadband model for V, g, r, z magnitude prediction from observational metadata (moon position, transparency, eclipse fraction)
+- Variational Autoencoder (VAE) for sky spectra compression (7,781 wavelength points → 8-dimensional latent space)
+- Latent Diffusion Model (LDM) for generating realistic dark-time night-sky emission spectra conditioned on 8 observational parameters
+- Data utilities for downloading and loading DESI DR1 Sky Spectra Value-Added Catalog (VAC) with automatic SHA-256 integrity verification
+- Subset filtering methods for different observing conditions:
+  - `load_dark_time()` - Non-contaminated observations (sun/moon below horizon)
+  - `load_sun_contaminated()` - Twilight observations
+  - `load_moon_contaminated()` - Moon-bright observations
+- Data enrichment features:
+  - V-band magnitude computation from spectra
+  - Lunar eclipse fraction calculation
+  - Solar flux integration
+  - Galactic and ecliptic coordinate transformations
+- Command-line interface `desisky-data` for data management (download, verify, locate)
+- Multiple sampling methods for latent diffusion inference:
+  - DDPM (Denoising Diffusion Probabilistic Models)
+  - DDIM (Denoising Diffusion Implicit Models)
+  - Heun (probability-flow ODE solver)
+- Production-ready model I/O system with JSON metadata + binary weights
+- Automatic caching for downloaded data and pre-trained models
+- Comprehensive test suite with 123+ unit tests covering all major functionality
+- Example Jupyter notebooks:
+  - `00_quickstart.ipynb` - Quick introduction to loading models and data
+  - `01_broadband_training.ipynb` - Train broadband model
+  - `02_vae_inference.ipynb` - VAE encoding/decoding
+  - `03_vae_analysis.ipynb` - Latent space analysis
+  - `04_vae_training.ipynb` - Train VAE from scratch
+  - `05_ldm_inference.ipynb` - Generate sky spectra with LDM
+  - `06_ldm_training.ipynb` - Train LDM from scratch
+- JAX/Equinox-based models with automatic differentiation for high-performance inference
+- PyTorch DataLoader integration for training workflows
+- Support for CPU and CUDA (GPU) installations
+- MIT License
+
+[unreleased]: https://github.com/MatthewDowicz/desisky/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/MatthewDowicz/desisky/releases/tag/v0.1.0

--- a/src/desisky/__about__.py
+++ b/src/desisky/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present MatthewDowicz <mjdowicz@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1"
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary

This PR prepares the v0.1.0 release of `desisky`, marking the first official release with a complete set of features for DESI sky modeling.

## Changes

### Version & Documentation
- Bump version from `0.0.1` to `0.1.0` in `__about__.py`
- Add `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
- Adopt [Semantic Versioning](https://semver.org/spec/v2.0.0.html) for future releases

### Release Highlights (v0.1.0)

This initial release includes:

**Models**:
- Latent Diffusion Model (LDM) for dark-time night-sky spectra generation
- Variational Autoencoder (VAE) for spectra compression (7,781 → 8 dimensions)
-  Broadband model for V, g, r, z magnitude prediction

**Data & Infrastructure**
- DESI DR1 Sky Spectra VAC loader with SHA-256 verification
- Subset filtering: `load_dark_time()`, `load_sun_contaminated()`, `load_moon_contaminated()`
- CLI tool: `desisky-data` for data management
- Comprehensive test suite (123+ tests)

**Documentation**
- Example notebooks (quickstart, training, inference, analysis)
- Updated README with installation and usage examples