### PR TITLE
feat: Add quality filter for known contaminated observations

### DIFF
--- a/src/desisky/data/__init__.py
+++ b/src/desisky/data/__init__.py
@@ -14,6 +14,7 @@ from ._enrich import (
     add_galactic_coordinates,
     add_ecliptic_coordinates,
 )
+from ._quality import filter_known_contamination, KNOWN_BAD_PERIODS
 from ._spectral import (
     measure_airglow_intensities,
     compute_broadband_mags,
@@ -38,6 +39,8 @@ __all__ = [
     "attach_solar_flux",
     "add_galactic_coordinates",
     "add_ecliptic_coordinates",
+    "filter_known_contamination",
+    "KNOWN_BAD_PERIODS",
     "get_validation_mask",
     "measure_airglow_intensities",
     "compute_broadband_mags",

--- a/src/desisky/data/_quality.py
+++ b/src/desisky/data/_quality.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: 2025-present MatthewDowicz <mjdowicz@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+"""Known data quality issues and filtering utilities for DESI sky spectra."""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Known contaminated observation periods.
+# Format: (start_night_YYYYMMDD, end_night_YYYYMMDD, description)
+KNOWN_BAD_PERIODS = [
+    (
+        20210604,
+        20210612,
+        "Arizona wildfire aerosol contamination (Telegraph & Mescal fires) — "
+        "anomalous blue excess and spectral shape distortion across all sky categories",
+    ),
+]
+
+
+def filter_known_contamination(metadata, flux=None, verbose=True):
+    """Filter out observations from known contaminated periods.
+
+    Removes spectra taken during time windows with documented environmental
+    contamination (e.g., wildfire smoke) that distorts spectral shapes in ways
+    not captured by standard quality cuts.
+
+    Parameters
+    ----------
+    metadata : pd.DataFrame
+        Observation metadata. Must contain a ``NIGHT`` column (YYYYMMDD int)
+        or an ``MJD`` column from which NIGHT can be computed.
+    flux : np.ndarray, optional
+        Flux array with the same number of rows as metadata. If provided,
+        rows are removed in parallel with metadata.
+    verbose : bool, default True
+        Print a summary of removed observations.
+
+    Returns
+    -------
+    metadata : pd.DataFrame
+        Filtered metadata with reset index.
+    flux : np.ndarray or None
+        Filtered flux array, or None if flux was not provided.
+    n_removed : int
+        Number of observations removed.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from desisky.data import filter_known_contamination
+    >>> meta = pd.read_csv("my_metadata.csv")
+    >>> flux = np.load("my_flux.npy")
+    >>> meta, flux, n = filter_known_contamination(meta, flux)
+    """
+    import warnings
+
+    if len(KNOWN_BAD_PERIODS) == 0:
+        return metadata, flux, 0
+
+    night = _resolve_night_column(metadata)
+    if night is None:
+        if verbose:
+            warnings.warn(
+                "Quality filter skipped: metadata has no 'NIGHT' or 'MJD' column. "
+                "Known contaminated observations may be present.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return metadata, flux, 0
+
+    bad_mask = np.zeros(len(metadata), dtype=bool)
+    details = []
+    for start, end, reason in KNOWN_BAD_PERIODS:
+        period_mask = (night >= start) & (night <= end)
+        n = int(period_mask.sum())
+        if n > 0:
+            bad_mask |= period_mask
+            details.append(f"  {n} spectra from NIGHT {start}-{end}: {reason}")
+
+    n_removed = int(bad_mask.sum())
+    if n_removed > 0 and verbose:
+        print(
+            f"Quality filter: removed {n_removed} spectra from "
+            f"known contaminated periods:"
+        )
+        for d in details:
+            print(d)
+
+    good = ~bad_mask
+    metadata_out = metadata[good].reset_index(drop=True)
+    flux_out = flux[good] if flux is not None else None
+    return metadata_out, flux_out, n_removed
+
+
+def _resolve_night_column(metadata):
+    """Get NIGHT as an int array from metadata, computing from MJD if needed."""
+    if "NIGHT" in metadata.columns:
+        return metadata["NIGHT"].astype(int).values
+
+    if "MJD" in metadata.columns:
+        import pandas as pd
+
+        dates = pd.to_datetime(
+            metadata["MJD"].values + 2400000.5, origin="julian", unit="D"
+        )
+        return (dates.year * 10000 + dates.month * 100 + dates.day).values
+
+    return None

--- a/src/desisky/data/skyspec.py
+++ b/src/desisky/data/skyspec.py
@@ -126,6 +126,11 @@ class SkySpecVAC:
         If True, downloads the dataset when missing.
     verify : bool, default True
         If True and a SHA-256 checksum is known, verify integrity after download.
+    exclude_known_bad : bool, default True
+        If True, automatically remove observations from known contaminated
+        periods (e.g., June 4-12 2021 Arizona wildfire aerosol event). See
+        ``desisky.data.KNOWN_BAD_PERIODS`` for the full list. Set to False
+        to load all observations including known bad data.
 
     Attributes
     ----------
@@ -174,6 +179,7 @@ class SkySpecVAC:
         version: str = "v1.0",
         download: bool = False,
         verify: bool = True,
+        exclude_known_bad: bool = True,
     ):
         if version not in REGISTRY:
             raise KeyError(f"Unknown SkySpec VAC version: {version!r}")
@@ -183,6 +189,7 @@ class SkySpecVAC:
         self.dir = ensure_dir(base / spec.subdir)
         self.path = self.dir / spec.filename
         self.version = version
+        self.exclude_known_bad = exclude_known_bad
         self._loaded: Optional[Tuple] = None  # memoized data
 
         if not self.path.exists():
@@ -299,6 +306,13 @@ class SkySpecVAC:
             except ImportError as e:
                 import warnings
                 warnings.warn(f"Skipping ecliptic coord enrichment: {e}", UserWarning, stacklevel=3)
+
+        # Remove known contaminated observations
+        if self.exclude_known_bad:
+            from ._quality import filter_known_contamination
+            metadata, flux, _ = filter_known_contamination(
+                metadata, flux, verbose=True,
+            )
 
         return wavelength, flux, metadata
 

--- a/src/desisky/scripts/train_broadband.py
+++ b/src/desisky/scripts/train_broadband.py
@@ -85,6 +85,10 @@ def parse_args():
                         help="Comma-separated wandb tags")
     parser.add_argument("--log-every", type=int, default=1)
     parser.add_argument("--viz-every", type=int, default=50)
+    # Quality filtering
+    parser.add_argument("--no-quality-filter", action="store_true",
+                        help="Disable automatic removal of known contaminated "
+                             "observations (e.g., June 2021 wildfire event)")
     # Other
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--print-every", type=int, default=50)
@@ -121,6 +125,13 @@ def main():
 
         print(f"  Loaded user data from {args.data_path} ({len(metadata):,} rows)")
 
+        # Remove known contaminated observations
+        if not args.no_quality_filter:
+            from desisky.data import filter_known_contamination
+            metadata, _, _ = filter_known_contamination(
+                metadata, verbose=True,
+            )
+
         # User data has pre-computed magnitudes, so we bypass SkyBrightnessDataset
         # (which requires raw spectra + the SKY_MAG_*_SPEC column naming convention).
         # Build inputs/targets arrays directly from the named columns.
@@ -136,7 +147,8 @@ def main():
         )
     else:
         from desisky.data import SkySpecVAC
-        vac = SkySpecVAC(version="v1.0", download=True)
+        vac = SkySpecVAC(version="v1.0", download=True,
+                         exclude_known_bad=not args.no_quality_filter)
         wavelength, flux, metadata = vac.load_moon_contaminated()
         print(f"  Loaded {len(metadata):,} moon-contaminated observations")
 

--- a/src/desisky/scripts/train_ldm.py
+++ b/src/desisky/scripts/train_ldm.py
@@ -211,6 +211,10 @@ def parse_args():
     parser.add_argument("--wandb-tags", type=str, default="")
     parser.add_argument("--log-every", type=int, default=1)
     parser.add_argument("--viz-every", type=int, default=20)
+    # Quality filtering
+    parser.add_argument("--no-quality-filter", action="store_true",
+                        help="Disable automatic removal of known contaminated "
+                             "observations (e.g., June 2021 wildfire event)")
     # Other
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--print-every", type=int, default=5)
@@ -265,6 +269,15 @@ def main():
             conditioning = data["conditioning"]
             wavelength = data["wavelength"]
             print(f"  Loaded pre-processed data: {flux.shape[0]:,} spectra")
+            if not args.no_quality_filter:
+                import warnings
+                warnings.warn(
+                    "Quality filter cannot be applied to .npz data (no metadata). "
+                    "Ensure your data was pre-filtered, or use "
+                    "desisky.data.filter_known_contamination() during data "
+                    "preparation.",
+                    UserWarning, stacklevel=1,
+                )
         elif ext in (".fits", ".csv"):
             # Raw data with metadata columns — auto-filter by variant
             if ext == ".fits":
@@ -289,6 +302,13 @@ def main():
             metadata = metadata[variant_mask].reset_index(drop=True)
             print(f"  Filtered {variant}: {len(metadata):,} / {n_before:,} spectra")
 
+            # Remove known contaminated observations
+            if not args.no_quality_filter:
+                from desisky.data import filter_known_contamination
+                metadata, flux, _ = filter_known_contamination(
+                    metadata, flux, verbose=True,
+                )
+
             # Enrich and extract conditioning
             from desisky.data import (
                 attach_solar_flux, add_galactic_coordinates,
@@ -312,7 +332,8 @@ def main():
         print(f"  Loaded {len(flux):,} {variant} spectra from {p.name}")
     else:
         from desisky.data import SkySpecVAC
-        vac = SkySpecVAC(version="v1.0", download=True)
+        vac = SkySpecVAC(version="v1.0", download=True,
+                         exclude_known_bad=not args.no_quality_filter)
         # Map CLI variant names to SkySpecVAC method names
         loader_names = {
             "dark": "load_dark_time",

--- a/src/desisky/scripts/train_vae.py
+++ b/src/desisky/scripts/train_vae.py
@@ -161,6 +161,10 @@ def parse_args():
     parser.add_argument("--wandb-tags", type=str, default="")
     parser.add_argument("--log-every", type=int, default=1)
     parser.add_argument("--viz-every", type=int, default=10)
+    # Quality filtering
+    parser.add_argument("--no-quality-filter", action="store_true",
+                        help="Disable automatic removal of known contaminated "
+                             "observations (e.g., June 2021 wildfire event)")
     # Other
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--print-every", type=int, default=10)
@@ -177,7 +181,9 @@ def main():
     # [1/5] Load Data
     print("\n[1/5] Loading sky spectra...")
     from desisky.data import SkySpecVAC
-    vac = SkySpecVAC(version="v1.0", download=True)
+    quality_filter = not args.no_quality_filter
+    vac = SkySpecVAC(version="v1.0", download=True,
+                     exclude_known_bad=quality_filter)
 
     if args.data_path:
         data = np.load(args.data_path)
@@ -185,6 +191,14 @@ def main():
         metadata = None
         # DESI wavelength grid for wandb CDF visualizations
         wavelength, _, _ = vac.load()
+        if quality_filter:
+            import warnings
+            warnings.warn(
+                "Quality filter cannot be applied to .npz data (no metadata). "
+                "Ensure your data was pre-filtered, or use "
+                "desisky.data.filter_known_contamination() during data preparation.",
+                UserWarning, stacklevel=1,
+            )
         print(f"  Loaded user data: {flux.shape[0]:,} spectra from {args.data_path}")
     else:
         wavelength, flux, metadata = vac.load()

--- a/tests/test_data_download.py
+++ b/tests/test_data_download.py
@@ -411,7 +411,7 @@ def test_data_module_all_matches_exports():
     from desisky import data
 
     assert hasattr(data, "__all__")
-    assert len(data.__all__) == 21  # Includes spectral extraction exports
+    assert len(data.__all__) == 23  # Includes spectral extraction + quality filter exports
 
     for symbol in data.__all__:
         assert hasattr(data, symbol), f"__all__ contains {symbol} but it's not exported"

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -478,8 +478,9 @@ class TestSkySpecVACEnrichment:
         wave, flux, meta = vac.load()
 
         assert wave.shape == (7781,)
-        assert flux.shape[0] == 9176
-        assert len(meta) == 9176
+        # 9176 total minus known contaminated observations (e.g., June 2021 fires)
+        assert flux.shape[0] == len(meta)
+        assert len(meta) < 9176
 
         # All 5 enrichments should be present
         assert 'SKY_MAG_V_SPEC' in meta.columns
@@ -661,3 +662,92 @@ class TestSkySpecVACEnrichment:
         assert np.array_equal(wave_dark, wave_sun), "Wavelength arrays should be identical"
         assert np.array_equal(wave_dark, wave_moon), "Wavelength arrays should be identical"
         assert len(wave_dark) == 7781, "Wavelength array should have 7781 points"
+
+
+class TestQualityFilter:
+    """Tests for the known contamination quality filter."""
+
+    def test_filter_removes_bad_nights(self):
+        """Test that filter_known_contamination removes the expected nights."""
+        import pandas as pd
+        from desisky.data import filter_known_contamination
+
+        meta = pd.DataFrame({
+            "NIGHT": [20210601, 20210605, 20210610, 20210615, 20220101],
+        })
+        flux = np.ones((5, 10))
+
+        meta_out, flux_out, n_removed = filter_known_contamination(
+            meta, flux, verbose=False,
+        )
+        assert n_removed == 2  # June 5 and June 10
+        assert len(meta_out) == 3
+        assert flux_out.shape[0] == 3
+        assert set(meta_out["NIGHT"]) == {20210601, 20210615, 20220101}
+
+    def test_filter_no_bad_nights(self):
+        """Test that filter passes through data with no bad nights."""
+        import pandas as pd
+        from desisky.data import filter_known_contamination
+
+        meta = pd.DataFrame({"NIGHT": [20220101, 20220201, 20220301]})
+        meta_out, flux_out, n_removed = filter_known_contamination(
+            meta, verbose=False,
+        )
+        assert n_removed == 0
+        assert len(meta_out) == 3
+        assert flux_out is None
+
+    def test_filter_works_with_mjd(self):
+        """Test that filter can compute NIGHT from MJD column."""
+        import pandas as pd
+        from desisky.data import filter_known_contamination
+
+        # MJD for June 6, 2021 is approximately 59371
+        meta = pd.DataFrame({"MJD": [59371.5, 59400.5]})
+        meta_out, _, n_removed = filter_known_contamination(
+            meta, verbose=False,
+        )
+        assert n_removed == 1
+        assert len(meta_out) == 1
+
+    def test_filter_warns_without_night_or_mjd(self):
+        """Test that filter warns when no NIGHT or MJD column exists."""
+        import pandas as pd
+        import warnings
+        from desisky.data import filter_known_contamination
+
+        meta = pd.DataFrame({"SUNALT": [-30.0, -25.0]})
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            meta_out, _, n_removed = filter_known_contamination(
+                meta, verbose=True,
+            )
+            assert n_removed == 0
+            assert len(meta_out) == 2
+            assert len(w) == 1
+            assert "Quality filter skipped" in str(w[0].message)
+
+    def test_exclude_known_bad_false_keeps_all(self):
+        """Test that SkySpecVAC with exclude_known_bad=False keeps all data."""
+        from desisky.data import SkySpecVAC
+
+        pytest.importorskip("speclite")
+        pytest.importorskip("astropy")
+
+        vac = SkySpecVAC(version="v1.0", download=False, exclude_known_bad=False)
+        _, flux, meta = vac.load()
+        assert len(meta) == 9176
+        assert flux.shape[0] == 9176
+
+    def test_exclude_known_bad_true_removes_data(self):
+        """Test that SkySpecVAC with exclude_known_bad=True removes data."""
+        from desisky.data import SkySpecVAC
+
+        pytest.importorskip("speclite")
+        pytest.importorskip("astropy")
+
+        vac = SkySpecVAC(version="v1.0", download=False, exclude_known_bad=True)
+        _, flux, meta = vac.load()
+        assert len(meta) < 9176
+        assert flux.shape[0] == len(meta)


### PR DESCRIPTION
## Summary

- Add `filter_known_contamination()` utility and `KNOWN_BAD_PERIODS` constant to remove spectra from documented environmental contamination events (June 4-12, 2021 Arizona wildfire aerosol event, 181 spectra)
- Integrate into `SkySpecVAC` via `exclude_known_bad` parameter (default `True`)
- Add `--no-quality-filter` opt-out flag to all training CLI scripts (`train_vae`, `train_ldm`, `train_broadband`)
- Update tests: relax hardcoded row counts, add 6-test `TestQualityFilter` suite

## Context
Outlier analysis of DESI sky spectra identified a 9-day window (June 4-12, 2021) where Arizona wildfires caused anomalous spectral shapes (2x blue/red excess, 58% GFA transparency measurements were normal during the event, indicating the spectral distortion is not caused by atmospheric extinction (e.g., thick smoke or clouds reducing throughput). The filter is applied by default everywhere. SkySpecVAC users get it automatically, custom data users can call the utility function directly.

## Test plan
- [x] All 382 tests pass (376 existing + 6 new)
- [x] Verify notebooks still run with filtered data (row counts are dynamic, no changes needed)
