### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-24
+
 ### Added
 
 - **NERSC Perlmutter A100 training support** — enables VAE, LDM, and broadband training on Perlmutter

--- a/src/desisky/__about__.py
+++ b/src/desisky/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present MatthewDowicz <mjdowicz@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.8.0"
+__version__ = "0.9.0"


### PR DESCRIPTION
Bumps version 0.8.0 → 0.9.0 and finalizes the CHANGELOG.

See `[0.9.0]` section in CHANGELOG.md for the full changelist. Headline items:
- NERSC Perlmutter A100 training support (VAE workaround + standard CLI for LDM/broadband)
- Perlmutter benchmark results in `docs/BENCHMARKS.md`
- New `notebooks/` directory with three analysis/presentation notebooks
- Broadband `--data-path` + `--wandb` compatibility fixes