### PR TITLE
chore: Mark notebooks/ as documentation for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Treat notebook directories as documentation so they don't dominate
+# GitHub's language stats (embedded base64 figure outputs inflate byte counts).
+examples/* linguist-documentation
+notebooks/* linguist-documentation

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Treat notebook directories as documentation so they don't dominate
-# GitHub's language stats (embedded base64 figure outputs inflate byte counts).
-examples/* linguist-documentation
+# Treat the analysis/presentation notebooks as documentation so they don't
+# dominate GitHub's language stats (the embedded base64 figure outputs in
+# the presentation notebook alone are ~12 MB).
 notebooks/* linguist-documentation


### PR DESCRIPTION
Adds `.gitattributes` telling GitHub linguist to treat `notebooks/` as documentation, so its byte count (dominated by base64-encoded figure outputs in the DESI presentation notebook, ~12 MB alone) doesn't swamp the repo's Languages sidebar.

`examples/` is intentionally left in language stats — those are user-facing tutorial notebooks that represent how users learn the package.

After merging, the Languages sidebar should recompute on the next push to main.

## Test plan
- [x] CI passes (`.gitattributes` doesn't affect tests)
- [ ] Languages bar updates after merge
